### PR TITLE
Doc fixes for `net_reduce`

### DIFF
--- a/R/goldbricker.R
+++ b/R/goldbricker.R
@@ -26,7 +26,7 @@
 #' Using the threshold argument, one can set the proportion of correlations which is deemed "too low". All pairs of nodes
 #' which fall below this threshold are returned as defined "bad pairs".
 #'
-#' Pairs can then be combined using the reduce_net function
+#' Pairs can then be combined using the net_reduce function
 #'
 #' Note: to quickly change the threshold, one may simply enter an object of class "goldbricker" in the data argument, and change the threshold.
 #' The p-value cannot be modified in the same fashion, as re-computation is necessary.

--- a/man/goldbricker.Rd
+++ b/man/goldbricker.Rd
@@ -54,7 +54,7 @@ significantly different for each different pair of nodes.
 Using the threshold argument, one can set the proportion of correlations which is deemed "too low". All pairs of nodes
 which fall below this threshold are returned as defined "bad pairs".
 
-Pairs can then be combined using the reduce_net function
+Pairs can then be combined using the net_reduce function
 
 Note: to quickly change the threshold, one may simply enter an object of class "goldbricker" in the data argument, and change the threshold.
 The p-value cannot be modified in the same fashion, as re-computation is necessary.


### PR DESCRIPTION
I've made a change to the docs: the exported function is called `net_reduce`, but the docs mention a function called `reduce_net` which isn't exported by this package.

Also, it looks like version 1.4.0 of this version isn't tagged on git but is on CRAN. Is the local version of the code ahead of this repo?